### PR TITLE
Print errors to stderr instead of stdout

### DIFF
--- a/lib/flags.js
+++ b/lib/flags.js
@@ -242,7 +242,7 @@ function throwFlagParseError(args, i, msg) {
       new Array(args[i].length + 1).join('^');
 
   if (exports.exitOnError) {
-    console.log(msg);
+    console.error(msg);
     process.exit(1);
   } else {
     throw Error(msg);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "flags",
-  "version" : "0.1.0",
+  "version" : "0.1.1",
   "description" : "Flag library for node.js",
   "keywords" : ["flag", "args", "command line"],
   "repository" : {


### PR DESCRIPTION
This is particularly useful when the result of something using flags is being redirected elsewhere, e.g. `node cli.js > output.log`.  
