### PR TITLE
Enable npm test command

### DIFF
--- a/lib/flags_test.js
+++ b/lib/flags_test.js
@@ -1,5 +1,5 @@
 
-var flags = require('flags');
+var flags = require('./flags');
 flags.exitOnError = false;
 
 exports.testGlobalFlagsObject = function(test) {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,11 @@
     "url" : "http://pupius.co.uk"
   },
   "main" : "./lib/flags.js",
-  "directories": {"lib": "./lib"}
+  "directories": {"lib": "./lib"},
+  "scripts": {
+    "test": "nodeunit lib/flags_test.js"
+  },
+  "devDependencies": {
+    "nodeunit": "^0.9.0"
+  }
 }


### PR DESCRIPTION
This will allow someone to just type `npm test` in the root of the repo and it'll automatically run. The `devDependencies` were added since this requires nodeunit to test. It will only require those dependencies if someone ran `npm install` in the root of the repo (like what Travis CI does). Just doing `npm install flags` won't require nodeunit.