### PR TITLE
Command-line arguments not recognised as flags are returned in an array from parse() instead of triggering an error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then on the command line:
  * Flag names should be prefixed with two dashes: e.g. `--flagname`
  * Values can be separated from the name with either an equal sign or a space: e.g. `--flagname=flagvalue` or `--flagname flagvalue`
  * Complex string flags should be quoted: e.g. `--flag="some flag with spaces"`
- * Additional non-flag arguments can be passed by adding `--` before the subsequent args.  The remaining args will be returned from `flags.parse()` as an array, e.g. `--one --two -- other stuff here`
+ * Any arguments which are not recognised as flags will be returned from parse() in an array. Adding `--` on the command line stops flag processing and returns all the rest of the arguments.  e.g. `--flag1 --flag2 arg1 -- --arg2 --arg3` will return an array of `['arg1', '--arg2', '--arg3']` assuming `flag1` and `flag2` are defined flags.
 
 ## Defining Flags
 

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -172,8 +172,9 @@ exports.isSet = function(name) {
  */
 exports.parse = function(opt_args, opt_ignoreUnrecognized) {
   var args = opt_args || process.argv.slice(2);
-  if (parseCalled) return;
-  
+  if (parseCalled) return nonflagArgs;
+  nonflagArgs = [];
+  var stopChecking = false;
   var parsedFlags = {};
   var lastflag = null;
   for (var i = 0; i < args.length; i++) {
@@ -181,7 +182,10 @@ exports.parse = function(opt_args, opt_ignoreUnrecognized) {
     
     // Terminate any flag processing
     if (arg == '--') {
-      break;
+      stopChecking = true;
+    } 
+    else if (stopChecking) {
+      nonflagArgs.push(arg);
     
     // Handle a typical long form flag --foo or --foo=bar.
     } else if (arg.substr(0, 2) == '--') {
@@ -218,7 +222,8 @@ exports.parse = function(opt_args, opt_ignoreUnrecognized) {
     
     // For now we only handle simple flags like --foo=bar, so fail out.
     } else {
-      throwFlagParseError(args, i, 'Invalid argument "' + arg + '"');
+      //throwFlagParseError(args, i, 'Invalid argument "' + arg + '"');
+      nonflagArgs.push(arg);
     }
   }
   
@@ -229,12 +234,8 @@ exports.parse = function(opt_args, opt_ignoreUnrecognized) {
     exports.help();
     process.exit(0);
   }
-  
-  if (i != args.length) {
-    return args.slice(i + 1);
-  } else {
-    return [];
-  }
+
+  return nonflagArgs;
 };
 
 
@@ -242,7 +243,7 @@ exports.parse = function(opt_args, opt_ignoreUnrecognized) {
 //==================
 
 var parseCalled = false;
-
+var nonflagArgs = [];
 
 function throwFlagParseError(args, i, msg) {
   // Show a nice error message with the offending arg underlined.

--- a/lib/flags_test.js
+++ b/lib/flags_test.js
@@ -204,11 +204,29 @@ exports.testReturnValue = function(test) {
 };
 
 exports.testIsSet = function(test) {
-    flags.reset();
-    flags.defineInteger('one', 1);
-    flags.defineInteger('two', 2);
-    flags.parse(['--one=11']);
-    test.strictEqual(true, flags.isSet('one'));
-    test.strictEqual(false, flags.isSet('two'));
-    test.done();
+  flags.reset();
+  flags.defineInteger('one', 1);
+  flags.defineInteger('two', 2);
+  flags.parse(['--one=11']);
+  test.strictEqual(true, flags.isSet('one'));
+  test.strictEqual(false, flags.isSet('two'));
+  test.done();
 };
+
+// Test mixing flags and regular arguments in the same command-line.
+exports.testNonFlags = function(test) {
+  flags.reset();
+  flags.defineInteger('one', 1);
+  var rv = flags.parse(['foo', '--one=11', 'bar']);
+  test.deepEqual(['foo', 'bar'], rv);
+  // flags.parse() ignores the arguments if called a second time.
+  var rv2 = flags.parse(['not', 'checked']);
+  test.deepEqual(['foo', 'bar'], rv);
+  
+  flags.reset();
+  flags.defineString('string', 'default', 'Test string');
+  var rv3 = flags.parse(['op1', '--string', 'string-value', '--', '--string', 'new-value', 'op2']);
+  test.deepEqual(['op1', '--string', 'new-value', 'op2'], rv3);
+  
+  test.done();
+}


### PR DESCRIPTION
Command-line arguments not recognised as flags are returned in an array from `parse()` instead of triggering an error.

The `--` is not required for this to happen, but it is still available in case you have arguments that look like flags.
The arguments are consistently returned from `parse()` each time it is called, until `reset()` is triggered.

This allows for more consistent Unix-like behaviour.