### PR TITLE
Update package.json to point to new dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.1",
   "description": "Flag library for node.js",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/flags.js",
+  "types": "dist/flags.d.ts",
   "files": [
     "/dist"
   ],


### PR DESCRIPTION
The latest release changed the names of the files in the `dist/` folder, but didnt update the `package.json` to reference the new file names.

This PR just updates the `package.json` so that the entries for `main` and `types` point to `dist/flags.js` and `dist/flags.d.ts` respectively. 

