### PR TITLE
flags → flg

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ pnpm add flg
 
 > ⚠️ _**Important Notice**_: This npm package was formerly known as `flags` and has been renamed to `flg`. Starting from version `3.0.0`, all updates will be published under this new package name.
 >
-> Existing `flags` releases will be marked as deprecated.
->
-> Migrate from `flags` to `flg` at your convenience to ensure you receive upcoming releases.
+> Migrate from `flags` to `flg` at your convenience to ensure you receive upcoming releases and avoid the deprecation notice of the previous name.
 >
 > _See [below](#package-name-update) for details and migration steps._
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ yarn add flg
 pnpm add flg
 ```
 
+> ⚠️ _**Important Notice**_: This npm package was formerly known as `flags` and has been renamed to `flg`. Starting from version `3.0.0`, all updates will be published under this new package name.
+>
+> Existing `flags` releases will be marked as deprecated.
+>
+> Migrate from `flags` to `flg` at your convenience to ensure you receive upcoming releases.
+>
+> _See [below](#package-name-update) for details and migration steps._
+
 ## Usage
 
 Here's a quick example of how to use Node-Flags:
@@ -116,6 +124,56 @@ Reset flags between test cases:
 ```javascript
 flags.reset();
 ```
+
+## Package name update
+
+The original release of `flags` version `0.2.2` has been republished as `flg` version `3.0.0`. This change was made to ensure consistency and avoid potential naming conflicts.
+
+All existing releases under the original `flags` name are still intact, so existing applications will not break.
+
+Migrate to `flg` to ensure you receive future releases.
+
+#### Migration Guide
+
+To upgrade your project to use the new `flg` package:
+
+1. Uninstall the old `flags` package:
+
+   ```bash
+    npm uninstall flags
+   ```
+
+2. Install the new `flg` package:
+
+   ```bash
+    npm install flg
+   ```
+
+3. Update all references in your code from `flags` to `flg`:
+
+   ```js
+   // before
+   import * as flags from "flags";
+
+   // after
+   import * as flags from "flg";
+   ```
+
+#### Versioning
+
+The new versioning starts from `3.0.0` to reflect the continuity of the `flags` package while aligning with semantic versioning best practices.
+
+#### Release history under original name
+
+| Version                                                    | Date                     |
+| ---------------------------------------------------------- | ------------------------ |
+| [flags@0.2.2](https://www.npmjs.com/package/flags/v/0.2.2) | 2024-09-16T17:32:20.498Z |
+| [flags@0.2.1](https://www.npmjs.com/package/flags/v/0.2.1) | 2024-09-14T00:38:28.225Z |
+| [flags@0.2.0](https://www.npmjs.com/package/flags/v/0.2.0) | 2024-09-13T23:04:51.567Z |
+| [flags@0.1.3](https://www.npmjs.com/package/flags/v/0.1.3) | 2015-02-27T02:29:55.285Z |
+| [flags@0.1.2](https://www.npmjs.com/package/flags/v/0.1.2) | 2014-04-18T01:55:57.093Z |
+| [flags@0.1.1](https://www.npmjs.com/package/flags/v/0.1.1) | 2011-11-02T19:53:15.783Z |
+| [flags@0.1.0](https://www.npmjs.com/package/flags/v/0.1.0) | 2011-04-04T14:58:55.383Z |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A flexible and easy-to-use command-line flag parsing library for Node.js applications.
 
-[![npm version](https://badge.fury.io/js/flags.svg)](https://badge.fury.io/js/flags)
+[![npm version](https://badge.fury.io/js/flg.svg)](https://badge.fury.io/js/flg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Features
@@ -18,11 +18,11 @@ A flexible and easy-to-use command-line flag parsing library for Node.js applica
 Install using your favorite package manager:
 
 ```bash
-npm install flags
+npm install flg
 # or
-yarn add flags
+yarn add flg
 # or
-pnpm add flags
+pnpm add flg
 ```
 
 ## Usage
@@ -30,7 +30,7 @@ pnpm add flags
 Here's a quick example of how to use Node-Flags:
 
 ```javascript
-import * as flags from "flags";
+import * as flags from "flg";
 
 // Define flags
 flags.defineString("name", "Anonymous", "Your name");

--- a/README.md
+++ b/README.md
@@ -161,10 +161,11 @@ To upgrade your project to use the new `flg` package:
 
 The new versioning starts from `3.0.0` to reflect the continuity of the `flags` package while aligning with semantic versioning best practices.
 
-#### Release history under original name
+#### Release history
 
 | Version                                                    | Date                     |
 | ---------------------------------------------------------- | ------------------------ |
+| [flg@3.0.0](https://www.npmjs.com/package/flg/v/3.0.0)     | _New name going forward_ |
 | [flags@0.2.2](https://www.npmjs.com/package/flags/v/0.2.2) | 2024-09-16T17:32:20.498Z |
 | [flags@0.2.1](https://www.npmjs.com/package/flags/v/0.2.1) | 2024-09-14T00:38:28.225Z |
 | [flags@0.2.0](https://www.npmjs.com/package/flags/v/0.2.0) | 2024-09-13T23:04:51.567Z |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@eslint/js": "^9.2.0",
     "@types/eslint": "^8.56.10",
+    "@types/node": "^22.10.10",
     "@typescript-eslint/parser": "^7.8.0",
     "eslint": "^9.2.0",
     "ts-node": "^10.9.2",
@@ -39,5 +40,6 @@
     "tsx": "^4.19.1",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.8.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "flags",
-  "version": "0.2.2",
+  "name": "flg",
+  "version": "3.0.0",
   "description": "Flag library for node.js",
   "type": "module",
   "main": "dist/flags.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/eslint':
         specifier: ^8.56.10
         version: 8.56.12
+      '@types/node':
+        specifier: ^22.10.10
+        version: 22.10.10
       '@typescript-eslint/parser':
         specifier: ^7.8.0
         version: 7.18.0(eslint@9.10.0)(typescript@5.6.2)
@@ -22,7 +25,7 @@ importers:
         version: 9.10.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.5.4)(typescript@5.6.2)
+        version: 10.9.2(@types/node@22.10.10)(typescript@5.6.2)
       tsup:
         specifier: ^8.0.2
         version: 8.2.4(tsx@4.19.1)(typescript@5.6.2)
@@ -366,8 +369,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@22.5.4':
-    resolution: {integrity: sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==}
+  '@types/node@22.10.10':
+    resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -1105,8 +1108,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1375,9 +1378,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@22.5.4':
+  '@types/node@22.10.10':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.20.0
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.10.0)(typescript@5.6.2))(eslint@9.10.0)(typescript@5.6.2)':
     dependencies:
@@ -2063,14 +2066,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@22.5.4)(typescript@5.6.2):
+  ts-node@10.9.2(@types/node@22.10.10)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.5.4
+      '@types/node': 22.10.10
       acorn: 8.12.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -2131,7 +2134,7 @@ snapshots:
 
   typescript@5.6.2: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.20.0: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
Renames the package and bumps the version to v3 as the existing flg package already uses versions up to v2.0.1.

An alternative would be to rename this package to a different name.